### PR TITLE
Esporta previsioni in CSV

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,8 @@ pip install -r requirements.txt
 python extract_forecasts.py
 ```
 
-I dati vengono salvati nella cartella `data/` con nome `previsioni_<data>.json`.
+I dati vengono salvati nella cartella `data/` con nome `previsioni_<data>.csv`.
+La prima colonna del file contiene la provincia, mentre la prima riga riporta gli orari delle previsioni.
 
 Per testare rapidamente si può limitare il numero di province elaborate:
 

--- a/extract_forecasts.py
+++ b/extract_forecasts.py
@@ -1,6 +1,6 @@
 import argparse
+import csv
 import datetime
-import json
 import os
 import unicodedata
 from typing import Dict, List, Tuple
@@ -73,20 +73,30 @@ def main(limit: int | None) -> None:
     if limit:
         provinces = provinces[:limit]
 
-    output: Dict[str, Dict] = {}
+    times: List[str] | None = None
+    rows: List[Tuple[str, List[float]]] = []
     for name in provinces:
         try:
             lat, lon = geocode(name)
             forecast = fetch_forecast(lat, lon)
-            output[name] = forecast
+            if times is None:
+                times = forecast["time"]
+            rows.append((name, forecast["temperature_2m"]))
             print(f"Raccolte previsioni per {name}")
         except Exception as exc:
             print(f"Errore per {name}: {exc}")
 
+    if not rows:
+        print("Nessuna previsione raccolta")
+        return
+
     os.makedirs("data", exist_ok=True)
-    filename = f"data/previsioni_{datetime.date.today().isoformat()}.json"
-    with open(filename, "w", encoding="utf-8") as f:
-        json.dump(output, f, ensure_ascii=False)
+    filename = f"data/previsioni_{datetime.date.today().isoformat()}.csv"
+    with open(filename, "w", newline="", encoding="utf-8") as f:
+        writer = csv.writer(f)
+        writer.writerow(["provincia"] + (times or []))
+        for province, temps in rows:
+            writer.writerow([province] + temps)
     print(f"Salvati dati in {filename}")
 
 


### PR DESCRIPTION
## Summary
- Esporta le previsioni meteo provinciali in formato CSV
- Documenta la struttura del file CSV

## Testing
- `pip install -r requirements.txt`
- `python extract_forecasts.py --limit 1` *(fallito: Unable to connect to proxy)*
- `python -m py_compile extract_forecasts.py`


------
https://chatgpt.com/codex/tasks/task_e_68c8155575348328b208dfccac7a4a5a