### PR TITLE
Extend forecast horizon to 10 days

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Previsioni Meteo Province Italiane
 
-Questo progetto fornisce uno script Python che ogni mattina scarica le previsioni di temperatura oraria per i prossimi cinque giorni di tutte le province italiane utilizzando l'API di [Open‑Meteo](https://open-meteo.com).
+Questo progetto fornisce uno script Python che ogni mattina scarica le previsioni di temperatura oraria per i prossimi dieci giorni di tutte le province italiane utilizzando l'API di [Open‑Meteo](https://open-meteo.com).
 
 ## Installazione
 

--- a/extract_forecasts.py
+++ b/extract_forecasts.py
@@ -51,7 +51,7 @@ def geocode(name: str) -> Tuple[float, float]:
     raise ValueError(f"Coordinate non trovate per {name}")
 
 
-def fetch_forecast(lat: float, lon: float, days: int = 5) -> Dict:
+def fetch_forecast(lat: float, lon: float, days: int = 10) -> Dict:
     """Fetch hourly temperature forecast for given coordinates."""
     resp = requests.get(
         "https://api.open-meteo.com/v1/forecast",


### PR DESCRIPTION
## Summary
- request ten days of hourly temperature data from Open-Meteo when downloading forecasts
- document the expanded forecast horizon in the project README

## Testing
- `python extract_forecasts.py --limit 1` *(fails: Unable to connect to proxy / 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68cd327305048328a9effb1f24fc63f5