### PR TITLE
Format forecast temperatures with comma decimals

### DIFF
--- a/extract_forecasts.py
+++ b/extract_forecasts.py
@@ -68,6 +68,12 @@ def fetch_forecast(lat: float, lon: float, days: int = 10) -> Dict:
     return resp.json()["hourly"]
 
 
+def format_temperature(value: float) -> str:
+    """Return the temperature using a comma as decimal separator."""
+
+    return f"{value}".replace(".", ",")
+
+
 def main(limit: int | None) -> None:
     provinces = get_provinces()
     if limit:
@@ -96,7 +102,8 @@ def main(limit: int | None) -> None:
         writer = csv.writer(f)
         writer.writerow(["provincia"] + (times or []))
         for province, temps in rows:
-            writer.writerow([province] + temps)
+            formatted_temps = [format_temperature(temp) for temp in temps]
+            writer.writerow([province] + formatted_temps)
     print(f"Salvati dati in {filename}")
 
 


### PR DESCRIPTION
## Summary
- add a helper to format forecast temperatures with a comma decimal separator before exporting the CSV

## Testing
- python -m compileall extract_forecasts.py

------
https://chatgpt.com/codex/tasks/task_e_68d166f5daf083288727d43f76cf3727